### PR TITLE
fix missing jsonEncode around body parameters, remove unused appName …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-## [0.0.1] - TODO: Add release date.
-## [1.0.0] - Initial release.
-## [1.0.1] - Update dependencies.
-
-* TODO: Describe initial release.
+## [1.0.0] - Initial release
+## [1.0.1] - Update dependencies
+## [1.1.0] - Null-safety
+## [1.1.1] - Fix json encoding issue

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your project's `pubspec.yaml` file
 
 ```yaml
 dependencies:
-  logdna: ^1.0.1
+  logdna: ^1.1.1
 ```
 
 Run `flutter pub get`

--- a/lib/logdna.dart
+++ b/lib/logdna.dart
@@ -1,4 +1,4 @@
-import 'dart:convert';
+import 'dart:convert' show jsonEncode;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -8,15 +8,13 @@ import 'package:logdna/models/dna_line.dart';
 import 'models/response.dart';
 
 class LogDNA {
-  /// logdna ingestion key
+  /// Ingestion key
   final String apiKey;
 
-  /// logdna app name
-  final String appName;
-
-  /// logdna hostname
+  /// The hostname of the source
   final String hostName;
-  LogDNA({required this.apiKey, required this.appName, required this.hostName});
+
+  LogDNA({required this.apiKey, required this.hostName});
 
   //// Sends the log via the logdna ingest API
   Future<DnaResponse> log(DnaLine line) async {
@@ -24,11 +22,12 @@ class LogDNA {
     try {
       final uri =
           Uri.parse("https://logs.logdna.com/logs/ingest?hostname=$hostName"
-              "&now=$now&apikey=$apiKey&appName=$appName");
+              "&now=$now&apikey=$apiKey");
 
-      http.Response response = await http.post(uri, body: {
-        "lines": jsonEncode([line]),
-      });
+      http.Response response = await http.post(uri,
+          body: jsonEncode({
+            "lines": [line]
+          }));
 
       if (response.statusCode == 200) {
         print(true);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: logdna
 description: A simple logdna client for Flutter. Push logs directly to your LogDNA dashboard in a few lines of code.
-version: 1.1.0
+version: 1.1.1
 repository: https://github.com/aligorithm/logdna_flutter
 issue_tracker: https://github.com/aligorithm/logdna_flutter/issues
 homepage: https://aligorithm.i.ng


### PR DESCRIPTION
Fix missing `jsonEncode` around body parameter, causing API call to return the following error:

```
"error":"Invalid Body, \"lines\" parameter not an array.","code":"BadRequest","status":"error"}
```

Also:
- Remove unused `appName` attribute, according to the [documentation](https://docs.logdna.com/reference/logsingest#logsingest) - app name is rather passed as an `app` attribute in each "line", which is to say, as a `DnaLine` attribute.
- Bump version to 1.1.1
- Update readme and changelog